### PR TITLE
added s3 bucket policy connecting iam policy document to bucket

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -26,6 +26,11 @@ resource "aws_s3_bucket" "management-bucket" {
   force_destroy = true
 }
 
+resource "aws_s3_bucket_policy" "management-bucket-policy" {
+  bucket = aws_s3_bucket.management-bucket.id
+  policy = data.aws_iam_policy_document.cloudtrail_s3_policy.json
+}
+
 #Create bucket ACL
 resource "aws_s3_bucket_acl" "management-bucket-acl" {
   bucket = aws_s3_bucket.management-bucket.id


### PR DESCRIPTION
Figured out even if you have under the iam policy document resource the correct bucket resource, you still have to attach the iam policy to the bucket, terraform isn't smart enough to do this for you. So I created this connector.