### PR TITLE
Fixing unique s3 names

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -19,3 +19,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:fb338d5dfafab907b8608bd66cad8ca9ae4679f8c62c2435c2056a38b719baa2",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.1"
+  hashes = [
+    "h1:Q+1ZwDtRYtFZLrPfpe9wnz7ulNvotLfM6WmwXFCGnSA=",
+    "zh:081d91c6f2602f76acef4a8f18d6bf392e104fe02a7885d167b06fe60adf7277",
+    "zh:0cbde9a961a3d4581edbf3af8137eac11e52b9b8b6117a6bda916150b68f7281",
+    "zh:1ad33b85a6e7400c438d33acd7c8a43c74d79711f11c7b8fd715bf94379a30ac",
+    "zh:5bfa3c71d28c9f961d1c46cdfa583b3a82a59d7298f4afe2c89081ebdf8863b8",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:a34a4286aff007a3834e13e70d28e7ce9b8ae162c5bef9412cae89df6226fe2d",
+    "zh:a6adefa0199b60cdc1accc617b24851c1f7da501891bc97d039d819749ead537",
+    "zh:c0ad3b665de7b7124d3159eefabcaae29f0bd8758847bfef6204afbd7e083bba",
+    "zh:d8a086da281e36949a70e8fce7aef449db34d65e12195e5856ddfb4e1b5747f2",
+    "zh:e1fcc67afc6b808a616bf53da6da18420fad7594cadca1b3a6d2a447f52dc8c5",
+    "zh:ed1877c6850c2d7101044fb3cf352ce81e5c3743aa78b1087bcf557b5163e887",
+    "zh:f7992c6fa4a639b1464dfdd7648a12e1ae6f05c6b8958c90c9705f09fd0b5bb5",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The following providers are used by this module:
 
 - <a name="provider_aws"></a> [aws](#provider_aws) (4.27.0)
 
+- <a name="provider_random"></a> [random](#provider_random)
+
 ## Modules
 
 No modules.
@@ -25,6 +27,8 @@ The following resources are used by this module:
 - [aws_cloudtrail.management-trail](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudtrail) (resource)
 - [aws_s3_bucket.management-bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) (resource)
 - [aws_s3_bucket_acl.management-bucket-acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) (resource)
+- [aws_s3_bucket_policy.management-bucket-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) (resource)
+- [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) (resource)
 - [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) (data source)
 - [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) (data source)
 - [aws_iam_policy_document.cloudtrail_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) (data source)
@@ -36,6 +40,14 @@ No required inputs.
 ## Optional Inputs
 
 The following input variables are optional (have default values):
+
+### <a name="input_namespace"></a> [namespace](#input_namespace)
+
+Description: Define the namespace here, example: dev, uat, prod
+
+Type: `string`
+
+Default: `"dev"`
 
 ### <a name="input_region"></a> [region](#input_region)
 

--- a/main.tf
+++ b/main.tf
@@ -20,10 +20,19 @@ resource "aws_cloudtrail" "management-trail" {
 data "aws_caller_identity" "current" {}
 data "aws_canonical_user_id" "current" {}
 
+# https://registry.terraform.io/providers/hashicorp/random/latest/docs
+#Create random bytes for unique bucket ID (This is stored in state and reused till resources need to be created again)
+resource "random_id" "id" {
+  byte_length = 8
+}
+
 #Create CloudTrail bucket
 resource "aws_s3_bucket" "management-bucket" {
-  bucket        = "trails-management-bucket"
+  bucket        = "trails-management-bucket-${var.namespace}-${random_id.id.hex}"
   force_destroy = true
+  depends_on = [
+    random_id.id
+  ]
 }
 
 resource "aws_s3_bucket_policy" "management-bucket-policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -3,3 +3,9 @@ variable "region" {
   default     = "us-west-2"
   description = "Define the region you'd wish the cloudtrail resources to be created in, example: us-west-2"
 }
+
+variable "namespace" {
+  type        = string
+  default     = "dev"
+  description = "Define the namespace here, example: dev, uat, prod"
+}


### PR DESCRIPTION
Implemented the random provider in terraform to generate unique bucket names to prevent name conflicts, tested in `synapse-tools` account and it's working as designed.

The bucket unique name bug was made aware in gatehawk, so this new version will be pinned there to fix broken uat infra pipeline 