### PR TITLE
moved dependency for cloudtrail trail up one level

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "aws_cloudtrail" "management-trail" {
   enable_log_file_validation    = true
   enable_logging                = true
   depends_on = [
-    data.aws_iam_policy_document.cloudtrail_s3_policy,
+    aws_s3_bucket_policy.management-bucket-policy,
     aws_s3_bucket_acl.management-bucket-acl
   ]
 }


### PR DESCRIPTION
- Moved dependency up one level to see if it fixes the bug we've encountered
```
module.cloudtrail.aws_s3_bucket_policy.management-bucket-policy: Creation complete after 1s [id=trails-management-bucket-prod]
╷
│ Error: creating CloudTrail: InsufficientS3BucketPolicyException: Incorrect S3 bucket policy is detected for bucket: trails-management-bucket-prod
│ 
│   with module.cloudtrail.aws_cloudtrail.management-trail,
│   on .terraform/modules/cloudtrail/main.tf line 2, in resource "aws_cloudtrail" "management-trail":
│    2: resource "aws_cloudtrail" "management-trail" {
│ 
╵
```