### PR TITLE
Use namespace in trail name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 #Create CloudTrail trail
 resource "aws_cloudtrail" "management-trail" {
-  name                          = "management-trail"
+  name                          = "${var.namespace}-management-trail"
   s3_bucket_name                = aws_s3_bucket.management-bucket.id
   include_global_service_events = true
   is_multi_region_trail         = true


### PR DESCRIPTION
This isn't technically very useful since accounts should only have one cloudtrail resource anyway, but I was doing some hacky testing by spinning up multiple environments in the same AWS account and ran into this conflict. I figured since we were already passing a namespace in anyway, we might as well use it in the trail name too. 